### PR TITLE
添加Controller层 IPC,支持类装饰器方式暴露 IPC方法

### DIFF
--- a/config/vite-plugin/controller-scan.vite.config.ts
+++ b/config/vite-plugin/controller-scan.vite.config.ts
@@ -9,7 +9,7 @@ const IPC_METHOD_MODIFIER_NAME = 'IpcMethod';
 interface BuildInfo {
   methods: string[];
   className: string;
-  instanceName: string;
+  interfaceName: string;
   path: string;
 }
 
@@ -94,12 +94,12 @@ function parseProject(tsConfigPath, tsRootPath = './config/typescript') {
       });
 
       const args = modifier.expression.arguments;
-      let instanceName = args[0]?.text ?? className;
-      instanceName = lowercaseFirst(instanceName);
+      let interfaceName = args[0]?.text ?? className;
+      interfaceName = lowercaseFirst(interfaceName);
       buildInfos.push({
         methods,
         className,
-        instanceName,
+        interfaceName,
         path: sourceFile.fileName
       });
     }
@@ -125,10 +125,10 @@ function infoToCode(buildInfo: BuildInfo[]) {
 type PickFunToPromise<T, K extends keyof T> = {
   [P in K]: FunToPromise<T[P]>;
 };`);
-  for (const { methods, path, className, instanceName } of buildInfo) {
+  for (const { methods, path, className, interfaceName } of buildInfo) {
     dtsContent.unshift(`import type ${className} from '@/main/ipc/decorator/controller/${className}';`);
     const methodsStr = methods.map((item) => `'${item}'`);
-    dtsContent.push(`   ${instanceName}: PickFunToPromise<${className}, ${methodsStr.join(' | ')}>;`);
+    dtsContent.push(`   ${interfaceName}: PickFunToPromise<${className}, ${methodsStr.join(' | ')}>;`);
   }
   dtsContent.push(`}`);
   const dts = dtsContent.join('\n') + '\n';

--- a/config/vite-plugin/controller-scan.vite.config.ts
+++ b/config/vite-plugin/controller-scan.vite.config.ts
@@ -1,0 +1,160 @@
+import ts from 'typescript';
+import path from 'path';
+import fs from 'fs';
+import type { UserConfig } from 'electron-vite';
+/* worker进程标识超类 */
+const CONTROLLER_MODIFIER_NAME = 'IpcController';
+const IPC_METHOD_MODIFIER_NAME = 'IpcMethod';
+
+interface BuildInfo {
+  methods: string[];
+  className: string;
+  instanceName: string;
+  path: string;
+}
+
+/**
+ *
+ * @param {ts.SourceFile} sourceFile
+ * @returns {boolean}
+ */
+function isMainPath(sourceFile) {
+  return sourceFile.fileName.startsWith('src/main');
+}
+
+function parseProject(tsConfigPath, tsRootPath = './config/typescript') {
+  const config = ts.readConfigFile(tsConfigPath, ts.sys.readFile).config;
+  const parsedCommandLine = ts.parseJsonConfigFileContent(config, ts.sys, tsRootPath, {
+    project: 'src/main'
+  });
+  const program = ts.createProgram(parsedCommandLine.fileNames, parsedCommandLine.options);
+  const sourceFiles = program.getSourceFiles();
+  const buildInfos: BuildInfo[] = [];
+  for (const sourceFile of sourceFiles) {
+    if (!isMainPath(sourceFile)) {
+      continue;
+    }
+    if (sourceFile.isDeclarationFile) {
+      continue;
+    }
+    // 获取文件中所有导出的类
+    const classes = sourceFile.statements.filter((statement) => ts.isClassDeclaration(statement));
+    if (classes.length === 0) {
+      continue;
+    }
+    for (const clazz of classes) {
+      // 获取该类的类装饰器
+      const modifiers = clazz.modifiers;
+      if (!modifiers) {
+        continue;
+      }
+      let modifier;
+      let hasExport = false;
+      for (const _modifier of modifiers) {
+        if (_modifier.kind == ts.SyntaxKind.ExportKeyword) {
+          hasExport = true;
+          continue;
+        }
+        if (_modifier.kind == ts.SyntaxKind.Decorator) {
+          // @ts-ignore
+          const modifierName = _modifier?.expression?.expression.escapedText;
+          if (modifierName != CONTROLLER_MODIFIER_NAME) {
+            continue;
+          } else {
+            modifier = _modifier;
+          }
+        }
+      }
+      if (!modifier) {
+        continue;
+      }
+      const className = clazz.name?.escapedText ?? '';
+      if (!hasExport) {
+        throw new Error(`业务类【${className}】未能正确导出，请使用export导出`);
+      }
+      if (!modifier) {
+        throw new Error('未能设置worker对应的启动装饰器');
+      }
+      const methods: string[] = [];
+      clazz.members.forEach((item) => {
+        if (item.kind === ts.SyntaxKind.MethodDeclaration) {
+          // @ts-ignore
+          const modifiers = item.modifiers;
+          if (modifiers) {
+            modifiers.forEach((_modifier) => {
+              const modifierName = _modifier?.expression?.expression.escapedText;
+              // console.log('modifier', modifierName);
+              if (modifierName === IPC_METHOD_MODIFIER_NAME) {
+                // @ts-ignore
+                methods.push(item.name?.escapedText);
+              }
+            });
+          }
+        }
+      });
+
+      const args = modifier.expression.arguments;
+      let instanceName = args[0]?.text ?? className;
+      instanceName = lowercaseFirst(instanceName);
+      buildInfos.push({
+        methods,
+        className,
+        instanceName,
+        path: sourceFile.fileName
+      });
+    }
+  }
+  return buildInfos;
+}
+
+function lowercaseFirst(str: string) {
+  if (str.length === 0) {
+    return str; // 如果字符串为空，则返回原字符串
+  }
+  return str.charAt(0).toLowerCase() + str.slice(1); // 连接第一个字符的小写形式和剩余的字符串
+}
+
+function infoToCode(buildInfo: BuildInfo[]) {
+  const dtsContent = [`export type ControllerApi = {`];
+  dtsContent.unshift(`type FunToPromise<T> = T extends (...args: infer Args) => infer R
+  ? R extends Promise<infer U>
+    ? (...args: Args) => Promise<U>
+    : (...args: Args) => Promise<R>
+  : never;
+
+type PickFunToPromise<T, K extends keyof T> = {
+  [P in K]: FunToPromise<T[P]>;
+};`);
+  for (const { methods, path, className, instanceName } of buildInfo) {
+    dtsContent.unshift(`import type ${className} from '@/main/ipc/decorator/controller/${className}';`);
+    const methodsStr = methods.map((item) => `'${item}'`);
+    dtsContent.push(`   ${instanceName}: PickFunToPromise<${className}, ${methodsStr.join(' | ')}>;`);
+  }
+  dtsContent.push(`}`);
+  const dts = dtsContent.join('\n') + '\n';
+  return dts;
+}
+
+function scanPlugin() {
+  const pwd = process.cwd();
+  const targetPath = path.resolve(pwd, 'src', 'preload', 'ControllerApi.d.ts');
+  const tsConfigPath = path.resolve(pwd, 'config', 'typescript', 'tsconfig.node.json');
+
+  return {
+    name: 'vite-plugin-worker-conf',
+    config() {
+      const infos = parseProject(tsConfigPath);
+      const code = infoToCode(infos);
+      fs.writeFileSync(targetPath, code, {
+        flag: 'w+'
+      });
+    }
+  };
+}
+
+export function usePlugin(config: UserConfig) {
+  config.main!.plugins = config.main!.plugins ?? [];
+  config.main!.plugins.push(scanPlugin());
+  return config;
+}
+export default usePlugin;

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import vue from '@vitejs/plugin-vue';
 import { useAliasPathPlugin } from './config/vite-plugin/alias.vite.config';
+import useControllerPlugin from './config/vite-plugin/controller-scan.vite.config';
 import type { UserConfig } from 'electron-vite';
 
 export default defineConfig((_cfg) => {
@@ -26,5 +27,6 @@ export default defineConfig((_cfg) => {
     }
   };
   useAliasPathPlugin(config);
+  useControllerPlugin(config);
   return config;
 });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.0",
-    "@electron-toolkit/utils": "^3.0.0"
+    "@electron-toolkit/utils": "^3.0.0",
+    "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config": "^1.0.2",

--- a/src/main/ipc/decorator/SacnController.ts
+++ b/src/main/ipc/decorator/SacnController.ts
@@ -1,0 +1,45 @@
+import { ipcMain, IpcMainInvokeEvent } from 'electron';
+import { run } from '../ctx';
+
+const controllers: any = import.meta.glob('./controller/**/*.ts', { eager: true });
+
+for (const key in controllers) {
+  if (Object.prototype.hasOwnProperty.call(controllers, key)) {
+    const controller = controllers[key];
+    for (const keyModule in controller) {
+      const module = controller[keyModule];
+
+      const isController: boolean = Reflect.hasMetadata('interfaceName', module);
+      const hasRoutes: boolean = Reflect.hasMetadata('routes', module);
+      if (!isController || !hasRoutes) {
+        continue;
+      }
+      const interfaceName = Reflect.getMetadata('interfaceName', module);
+      const routes = Reflect.getMetadata('routes', module);
+      const instance = new module();
+      routes.forEach((route) => {
+        const member = instance[route.propertyKey];
+        //获取类名
+        const className = instance.constructor.name;
+        //获取方法名
+        const methodName = route.propertyKey;
+        const postfix = interfaceName ? interfaceName : lowercaseFirst(className);
+        //获取ipc事件名
+        const ipcEventName = `${postfix}-${methodName}`;
+
+        ipcMain.handle(ipcEventName, (event: IpcMainInvokeEvent, ...args: any[]) => {
+          return run(event, () => {
+            return Promise.resolve(member(...args, event));
+          });
+        });
+        console.log(`controller: [${ipcEventName}] 注册了\n`);
+      });
+    }
+  }
+}
+function lowercaseFirst(str: string) {
+  if (str.length === 0) {
+    return str; // 如果字符串为空，则返回原字符串
+  }
+  return str.charAt(0).toLowerCase() + str.slice(1); // 连接第一个字符的小写形式和剩余的字符串
+}

--- a/src/main/ipc/decorator/controller/TestController.ts
+++ b/src/main/ipc/decorator/controller/TestController.ts
@@ -1,0 +1,26 @@
+import { IpcController, IpcMethod } from '..';
+
+@IpcController('hadaController')
+export default class TestController {
+  aa: string = 'aa';
+
+  /**
+   * 此方法未暴露
+   * @param username
+   * @param password
+   */
+  async login(username: string, password: string) {
+    console.log('login', username, password);
+  }
+
+  /**
+   * 测试方法
+   * @param username 用户名
+   * @param password 密码
+   */
+  @IpcMethod()
+  private test(username: string, password: string) {
+    console.log('login', username, password);
+    return 'test';
+  }
+}

--- a/src/main/ipc/decorator/controller/UserController.ts
+++ b/src/main/ipc/decorator/controller/UserController.ts
@@ -1,0 +1,15 @@
+import { IpcController, IpcMethod } from '..';
+
+@IpcController()
+export default class UserController {
+  @IpcMethod()
+  async login(username: string, password: string) {
+    console.log('login', username, password);
+    return 'testLogin';
+  }
+
+  @IpcMethod()
+  async test(username: string, password: string) {
+    console.log('login', username, password);
+  }
+}

--- a/src/main/ipc/decorator/index.ts
+++ b/src/main/ipc/decorator/index.ts
@@ -1,0 +1,28 @@
+export interface Route {
+  propertyKey: string | symbol;
+}
+/**
+ * 装饰Ipc暴露类
+ * @param interfaceName 指定实例接口名称 不传实例名称则默认使用类名 第一个字母小写
+ * @returns
+ */
+export function IpcController(interfaceName: string = ''): ClassDecorator {
+  return (target: any) => {
+    Reflect.defineMetadata('interfaceName', interfaceName, target);
+  };
+}
+export type RouterDecoratorFactory = () => MethodDecorator;
+
+export function createRouterDecorator(): RouterDecoratorFactory {
+  return () => (target: any, propertyKey: string | symbol, _descriptor: PropertyDescriptor) => {
+    const route: Route = {
+      propertyKey
+    };
+    if (!Reflect.hasMetadata('routes', target.constructor)) {
+      Reflect.defineMetadata('routes', [], target.constructor);
+    }
+    const routes = Reflect.getMetadata('routes', target.constructor);
+    routes.push(route);
+  };
+}
+export const IpcMethod: RouterDecoratorFactory = createRouterDecorator();

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,6 +1,8 @@
 import * as Handles from './handles';
 import { ipcMain, IpcMainInvokeEvent } from 'electron';
 import { run } from './ctx';
+import 'reflect-metadata';
+import './decorator/SacnController';
 
 /**
  * 深度代理ipc，支持深层ipc嵌套

--- a/src/preload/ControllerApi.d.ts
+++ b/src/preload/ControllerApi.d.ts
@@ -1,0 +1,15 @@
+import type UserController from '@/main/ipc/decorator/controller/UserController';
+import type TestController from '@/main/ipc/decorator/controller/TestController';
+type FunToPromise<T> = T extends (...args: infer Args) => infer R
+  ? R extends Promise<infer U>
+    ? (...args: Args) => Promise<U>
+    : (...args: Args) => Promise<R>
+  : never;
+
+type PickFunToPromise<T, K extends keyof T> = {
+  [P in K]: FunToPromise<T[P]>;
+};
+export type ControllerApi = {
+   hadaController: PickFunToPromise<TestController, 'test'>;
+   userController: PickFunToPromise<UserController, 'login' | 'test'>;
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -9,17 +9,18 @@ type DeepHandleApi<T extends Object> = {
   [key in keyof T]: T[key] extends Function ? ApiInvokeFunction<T[key]> : DeepHandleApi<T[key]>;
 };
 
-
 interface Notify {
   addListener<T extends IPC.NotifyEvent>(event: T, callback: IPC.NotifyCallback<T>);
   removeListener<T extends IPC.NotifyEvent>(event: T, callback: IPC.NotifyCallback<T>);
   removeAllListeners<T extends IPC.NotifyEvent>(event: T);
 }
 
+import type { ControllerApi } from './ControllerApi';
+
 declare global {
   interface Window {
     electron: ElectronAPI;
-    api: HandleApi;
+    api: HandleApi & ControllerApi;
     notify: Notify;
   }
 }

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -9,8 +9,13 @@ onMounted(() => {
   setTimeout(() => {
     flag.value = false;
   }, 10000);
-  setInterval(() => {
+  setInterval(async () => {
     window.api.message.shy.startle('hello');
+
+    const ss = await window.api.hadaController.test('111', '222');
+    console.log(ss);
+    const ss1 = await window.api.userController.login('333', '444');
+    console.log(ss1);
   }, 2000);
 });
 </script>


### PR DESCRIPTION
添加Controller层 IPC,支持类装饰器方式暴露 IPC方法， 支持自定义接口名  @IpcController('hadaController') 也可以不传入，不传入默认使用类名（第一个字母小写类名）暴露 IPC